### PR TITLE
Update to 17.3

### DIFF
--- a/backend_kms.c
+++ b/backend_kms.c
@@ -105,9 +105,12 @@ static void gbm_kms_bo_destroy(struct gbm_bo *_bo)
 	return;
 }
 
-static struct gbm_bo *gbm_kms_bo_create(struct gbm_device *gbm,
-					uint32_t width, uint32_t height,
-					uint32_t format, uint32_t usage)
+static struct gbm_bo *
+gbm_kms_bo_create(struct gbm_device *gbm,
+		  uint32_t width, uint32_t height,
+		  uint32_t format, uint32_t usage,
+		  const uint64_t *modifiers,
+		  const unsigned int count)
 {
 	struct gbm_kms_device *dev = (struct gbm_kms_device*)gbm;
 	struct gbm_kms_bo *bo;
@@ -313,11 +316,11 @@ static int gbm_kms_surface_set_bo(struct gbm_kms_surface *surface, int n, void *
 
 static void gbm_kms_surface_destroy(struct gbm_surface *_surface);
 
-static struct gbm_surface *gbm_kms_surface_create(struct gbm_device *gbm,
-						  uint32_t width,
-						  uint32_t height,
-						  uint32_t format,
-						  uint32_t flags)
+static struct gbm_surface *
+gbm_kms_surface_create(struct gbm_device *gbm,
+		       uint32_t width, uint32_t height,
+		       uint32_t format, uint32_t flags,
+		       const uint64_t *modifiers, const unsigned count)
 {
 	struct gbm_kms_surface *surface;
 	GBM_DEBUG("%s: %s: %d\n", __FILE__, __func__, __LINE__);

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 
 # Initialize Autoconf
 AC_PREREQ([2.60])
-AC_INIT([libgbm], [10.3.0],
+AC_INIT([libgbm], [17.3.3],
         [https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa], [libgbm])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])

--- a/gbm.c
+++ b/gbm.c
@@ -25,28 +25,25 @@
  *    Benjamin Franzke <benjaminfranzke@googlemail.com>
  */
 
-#define _BSD_SOURCE
-
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 
-#include <sys/types.h>
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "gbm.h"
 #include "gbmint.h"
-#include "common.h"
 #include "backend.h"
-
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
-
-struct gbm_device *devices[16];
-
-static int device_num = 0;
 
 /** Returns the file description for the gbm device
  *
@@ -58,7 +55,6 @@ gbm_device_get_fd(struct gbm_device *gbm)
    return gbm->fd;
 }
 
-/* FIXME: maybe superfluous, use udev subclass from the fd? */
 /** Get the backend name for the given gbm device
  *
  * \return The backend name string - this belongs to the device and must not
@@ -82,11 +78,25 @@ gbm_device_get_backend_name(struct gbm_device *gbm)
  *
  * \sa enum gbm_bo_format for the list of formats
  */
-int
+GBM_EXPORT int
 gbm_device_is_format_supported(struct gbm_device *gbm,
                                uint32_t format, uint32_t usage)
 {
    return gbm->is_format_supported(gbm, format, usage);
+}
+
+/** Get the number of planes that are required for a given format+modifier
+ *
+ * \param gbm The gbm device returned from gbm_create_device()
+ * \param format The format to query
+ * \param modifier The modifier to query
+ */
+GBM_EXPORT int
+gbm_device_get_format_modifier_plane_count(struct gbm_device *gbm,
+                                           uint32_t format,
+                                           uint64_t modifier)
+{
+   return gbm->get_format_modifier_plane_count(gbm, format, modifier);
 }
 
 /** Destroy the gbm device and free all resources associated with it.
@@ -101,32 +111,6 @@ gbm_device_destroy(struct gbm_device *gbm)
       gbm->destroy(gbm);
 }
 
-GBM_EXPORT struct gbm_device *
-_gbm_mesa_get_device(int fd)
-{
-   struct gbm_device *gbm = NULL;
-   struct stat buf;
-   dev_t dev;
-   int i;
-
-   if (fd < 0 || fstat(fd, &buf) < 0 || !S_ISCHR(buf.st_mode)) {
-      fprintf(stderr, "_gbm_mesa_get_device: invalid fd: %d\n", fd);
-      return NULL;
-   }
-
-   for (i = 0; i < device_num; ++i) {
-      dev = devices[i]->stat.st_rdev;
-      if (major(dev) == major(buf.st_rdev) &&
-          minor(dev) == minor(buf.st_rdev)) {
-         gbm = devices[i];
-         gbm->refcount++;
-         break;
-      }
-   }
-
-   return gbm;
-}
-
 /** Create a gbm device for allocating buffers
  *
  * The file descriptor passed in is used by the backend to communicate with
@@ -134,7 +118,7 @@ _gbm_mesa_get_device(int fd)
  * the file descriptor returned when opening a device such as \c
  * /dev/dri/card0
  *
- * \param fd The file descriptor for an backend specific device
+ * \param fd The file descriptor for a backend specific device
  * \return The newly created struct gbm_device. The resources associated with
  * the device should be freed with gbm_device_destroy() when it is no longer
  * needed. If the creation of the device failed NULL will be returned.
@@ -146,12 +130,9 @@ gbm_create_device(int fd)
    struct stat buf;
 
    if (fd < 0 || fstat(fd, &buf) < 0 || !S_ISCHR(buf.st_mode)) {
-      fprintf(stderr, "gbm_create_device: invalid fd: %d\n", fd);
+      errno = EINVAL;
       return NULL;
    }
-
-   if (device_num == 0)
-      memset(devices, 0, sizeof devices);
 
    gbm = _gbm_create_device(fd);
    if (gbm == NULL)
@@ -160,9 +141,6 @@ gbm_create_device(int fd)
    gbm->dummy = gbm_create_device;
    gbm->stat = buf;
    gbm->refcount = 1;
-
-   if (device_num < ARRAY_SIZE(devices)-1)
-      devices[device_num++] = gbm;
 
    return gbm;
 }
@@ -173,7 +151,7 @@ gbm_create_device(int fd)
  * \return The width of the allocated buffer object
  *
  */
-GBM_EXPORT unsigned int
+GBM_EXPORT uint32_t
 gbm_bo_get_width(struct gbm_bo *bo)
 {
    return bo->width;
@@ -184,7 +162,7 @@ gbm_bo_get_width(struct gbm_bo *bo)
  * \param bo The buffer object
  * \return The height of the allocated buffer object
  */
-GBM_EXPORT unsigned int
+GBM_EXPORT uint32_t
 gbm_bo_get_height(struct gbm_bo *bo)
 {
    return bo->height;
@@ -201,7 +179,20 @@ gbm_bo_get_height(struct gbm_bo *bo)
 GBM_EXPORT uint32_t
 gbm_bo_get_stride(struct gbm_bo *bo)
 {
-   return bo->stride;
+   return gbm_bo_get_stride_for_plane(bo, 0);
+}
+
+/** Get the stride for the given plane
+ *
+ * \param bo The buffer object
+ * \param plane for which you want the stride
+ *
+ * \sa gbm_bo_get_stride()
+ */
+GBM_EXPORT uint32_t
+gbm_bo_get_stride_for_plane(struct gbm_bo *bo, int plane)
+{
+   return bo->gbm->bo_get_stride(bo, plane);
 }
 
 /** Get the format of the buffer object
@@ -209,12 +200,104 @@ gbm_bo_get_stride(struct gbm_bo *bo)
  * The format of the pixels in the buffer.
  *
  * \param bo The buffer object
- * \return The format of buffer object, on of the GBM_FORMAT_* codes
+ * \return The format of buffer object, one of the GBM_FORMAT_* codes
  */
 GBM_EXPORT uint32_t
 gbm_bo_get_format(struct gbm_bo *bo)
 {
    return bo->format;
+}
+
+/** Get the bit-per-pixel of the buffer object's format
+ *
+ * The bits-per-pixel of the buffer object's format.
+ *
+ * Note; The 'in-memory pixel' concept makes no sense for YUV formats
+ * (pixels are the result of the combination of multiple memory sources:
+ * Y, Cb & Cr; usually these are even in separate buffers), so YUV
+ * formats are not supported by this function.
+ *
+ * \param bo The buffer object
+ * \return The number of bits0per-pixel of the buffer object's format.
+ */
+GBM_EXPORT uint32_t
+gbm_bo_get_bpp(struct gbm_bo *bo)
+{
+   switch (bo->format) {
+      default:
+         return 0;
+      case GBM_FORMAT_C8:
+      case GBM_FORMAT_R8:
+      case GBM_FORMAT_RGB332:
+      case GBM_FORMAT_BGR233:
+         return 8;
+      case GBM_FORMAT_GR88:
+      case GBM_FORMAT_XRGB4444:
+      case GBM_FORMAT_XBGR4444:
+      case GBM_FORMAT_RGBX4444:
+      case GBM_FORMAT_BGRX4444:
+      case GBM_FORMAT_ARGB4444:
+      case GBM_FORMAT_ABGR4444:
+      case GBM_FORMAT_RGBA4444:
+      case GBM_FORMAT_BGRA4444:
+      case GBM_FORMAT_XRGB1555:
+      case GBM_FORMAT_XBGR1555:
+      case GBM_FORMAT_RGBX5551:
+      case GBM_FORMAT_BGRX5551:
+      case GBM_FORMAT_ARGB1555:
+      case GBM_FORMAT_ABGR1555:
+      case GBM_FORMAT_RGBA5551:
+      case GBM_FORMAT_BGRA5551:
+      case GBM_FORMAT_RGB565:
+      case GBM_FORMAT_BGR565:
+         return 16;
+      case GBM_FORMAT_RGB888:
+      case GBM_FORMAT_BGR888:
+         return 24;
+      case GBM_FORMAT_XRGB8888:
+      case GBM_FORMAT_XBGR8888:
+      case GBM_FORMAT_RGBX8888:
+      case GBM_FORMAT_BGRX8888:
+      case GBM_FORMAT_ARGB8888:
+      case GBM_FORMAT_ABGR8888:
+      case GBM_FORMAT_RGBA8888:
+      case GBM_FORMAT_BGRA8888:
+      case GBM_FORMAT_XRGB2101010:
+      case GBM_FORMAT_XBGR2101010:
+      case GBM_FORMAT_RGBX1010102:
+      case GBM_FORMAT_BGRX1010102:
+      case GBM_FORMAT_ARGB2101010:
+      case GBM_FORMAT_ABGR2101010:
+      case GBM_FORMAT_RGBA1010102:
+      case GBM_FORMAT_BGRA1010102:
+         return 32;
+   }
+}
+
+/** Get the offset for the data of the specified plane
+ *
+ * Extra planes, and even the first plane, may have an offset from the start of
+ * the buffer object. This function will provide the offset for the given plane
+ * to be used in various KMS APIs.
+ *
+ * \param bo The buffer object
+ * \return The offset
+ */
+GBM_EXPORT uint32_t
+gbm_bo_get_offset(struct gbm_bo *bo, int plane)
+{
+   return bo->gbm->bo_get_offset(bo, plane);
+}
+
+/** Get the gbm device used to create the buffer object
+ *
+ * \param bo The buffer object
+ * \return Returns the gbm device with which the buffer object was created
+ */
+GBM_EXPORT struct gbm_device *
+gbm_bo_get_device(struct gbm_bo *bo)
+{
+	return bo->gbm;
 }
 
 /** Get the handle of the buffer object
@@ -231,34 +314,88 @@ gbm_bo_get_handle(struct gbm_bo *bo)
    return bo->handle;
 }
 
+/** Get a DMA-BUF file descriptor for the buffer object
+ *
+ * This function creates a DMA-BUF (also known as PRIME) file descriptor
+ * handle for the buffer object.  Each call to gbm_bo_get_fd() returns a new
+ * file descriptor and the caller is responsible for closing the file
+ * descriptor.
+
+ * \param bo The buffer object
+ * \return Returns a file descriptor referring to the underlying buffer or -1
+ * if an error occurs.
+ */
+GBM_EXPORT int
+gbm_bo_get_fd(struct gbm_bo *bo)
+{
+   return bo->gbm->bo_get_fd(bo);
+}
+
+/** Get the number of planes for the given bo.
+ *
+ * \param bo The buffer object
+ * \return The number of planes
+ */
+GBM_EXPORT int
+gbm_bo_get_plane_count(struct gbm_bo *bo)
+{
+   return bo->gbm->bo_get_planes(bo);
+}
+
+/** Get the handle for the specified plane of the buffer object
+ *
+ * This function gets the handle for any plane associated with the BO. When
+ * dealing with multi-planar formats, or formats which might have implicit
+ * planes based on different underlying hardware it is necessary for the client
+ * to be able to get this information to pass to the DRM.
+ *
+ * \param bo The buffer object
+ * \param plane the plane to get a handle for
+ *
+ * \sa gbm_bo_get_handle()
+ */
+GBM_EXPORT union gbm_bo_handle
+gbm_bo_get_handle_for_plane(struct gbm_bo *bo, int plane)
+{
+   return bo->gbm->bo_get_handle(bo, plane);
+}
+
+/**
+ * Get the chosen modifier for the buffer object
+ *
+ * This function returns the modifier that was chosen for the object. These
+ * properties may be generic, or platform/implementation dependent.
+ *
+ * \param bo The buffer object
+ * \return Returns the selected modifier (chosen by the implementation) for the
+ * BO.
+ * \sa gbm_bo_create_with_modifiers() where possible modifiers are set
+ * \sa gbm_surface_create_with_modifiers() where possible modifiers are set
+ * \sa define DRM_FORMAT_MOD_* in drm_fourcc.h for possible modifiers
+ */
+GBM_EXPORT uint64_t
+gbm_bo_get_modifier(struct gbm_bo *bo)
+{
+   return bo->gbm->bo_get_modifier(bo);
+}
+
 /** Write data into the buffer object
  *
  * If the buffer object was created with the GBM_BO_USE_WRITE flag,
- * this function can used to write data into the buffer object.  The
- * data is copied directly into the object and it's the responsiblity
+ * this function can be used to write data into the buffer object.  The
+ * data is copied directly into the object and it's the responsibility
  * of the caller to make sure the data represents valid pixel data,
  * according to the width, height, stride and format of the buffer object.
  *
  * \param bo The buffer object
  * \param buf The data to write
  * \param count The number of bytes to write
- * \return Returns -1 on error, 0 otherwise
+ * \return Returns 0 on success, otherwise -1 is returned an errno set
  */
 GBM_EXPORT int
 gbm_bo_write(struct gbm_bo *bo, const void *buf, size_t count)
 {
    return bo->gbm->bo_write(bo, buf, count);
-}
-
-/** Get the gbm device used to create the buffer object
- *
- * \param bo The buffer object
- * \return Returns the gbm device with which the buffer object was created
- */
-GBM_EXPORT struct gbm_device *
-gbm_bo_get_device(struct gbm_bo *bo)
-{
-	return bo->gbm;
 }
 
 /** Set the user data associated with a buffer object
@@ -316,7 +453,7 @@ gbm_bo_destroy(struct gbm_bo *bo)
  *
  * \return A newly allocated buffer that should be freed with gbm_bo_destroy()
  * when no longer needed. If an error occurs during allocation %NULL will be
- * returned.
+ * returned and errno set.
  *
  * \sa enum gbm_bo_format for the list of formats
  * \sa enum gbm_bo_flags for the list of usage flags
@@ -326,38 +463,56 @@ gbm_bo_create(struct gbm_device *gbm,
               uint32_t width, uint32_t height,
               uint32_t format, uint32_t usage)
 {
-   if (width == 0 || height == 0)
+   if (width == 0 || height == 0) {
+      errno = EINVAL;
       return NULL;
+   }
 
-   if (usage & GBM_BO_USE_CURSOR_64X64 &&
-       (width != 64 || height != 64))
-      return NULL;
-
-   return gbm->bo_create(gbm, width, height, format, usage);
+   return gbm->bo_create(gbm, width, height, format, usage, NULL, 0);
 }
 
+GBM_EXPORT struct gbm_bo *
+gbm_bo_create_with_modifiers(struct gbm_device *gbm,
+                             uint32_t width, uint32_t height,
+                             uint32_t format,
+                             const uint64_t *modifiers,
+                             const unsigned int count)
+{
+   if (width == 0 || height == 0) {
+      errno = EINVAL;
+      return NULL;
+   }
+
+   if ((count && !modifiers) || (modifiers && !count)) {
+      errno = EINVAL;
+      return NULL;
+   }
+
+   return gbm->bo_create(gbm, width, height, format, 0, modifiers, count);
+}
 /**
  * Create a gbm buffer object from an foreign object
  *
  * This function imports a foreign object and creates a new gbm bo for it.
  * This enabled using the foreign object with a display API such as KMS.
- * Currently two types of foreign objects are supported, indicated by the type
+ * Currently three types of foreign objects are supported, indicated by the type
  * argument:
  *
  *   GBM_BO_IMPORT_WL_BUFFER
  *   GBM_BO_IMPORT_EGL_IMAGE
  *   GBM_BO_IMPORT_FD
  *
- * The the gbm bo shares the underlying pixels but its life-time is
+ * The gbm bo shares the underlying pixels but its life-time is
  * independent of the foreign object.
  *
  * \param gbm The gbm device returned from gbm_create_device()
- * \param gbm The type of object we're importing
- * \param gbm Pointer to the external object
+ * \param type The type of object we're importing
+ * \param buffer Pointer to the external object
  * \param usage The union of the usage flags for this buffer
  *
  * \return A newly allocated buffer object that should be freed with
- * gbm_bo_destroy() when no longer needed.
+ * gbm_bo_destroy() when no longer needed. On error, %NULL is returned
+ * and errno is set.
  *
  * \sa enum gbm_bo_flags for the list of usage flags
  */
@@ -366,6 +521,59 @@ gbm_bo_import(struct gbm_device *gbm,
               uint32_t type, void *buffer, uint32_t usage)
 {
    return gbm->bo_import(gbm, type, buffer, usage);
+}
+
+/**
+ * Map a region of a gbm buffer object for cpu access
+ *
+ * This function maps a region of a gbm bo for cpu read and/or write
+ * access.
+ *
+ * \param bo The buffer object
+ * \param x The X (top left origin) starting position of the mapped region for
+ * the buffer
+ * \param y The Y (top left origin) starting position of the mapped region for
+ * the buffer
+ * \param width The width of the mapped region for the buffer
+ * \param height The height of the mapped region for the buffer
+ * \param flags The union of the GBM_BO_TRANSFER_* flags for this buffer
+ * \param stride Ptr for returned stride in bytes of the mapped region
+ * \param map_data Returned opaque ptr for the mapped region
+ *
+ * \return Address of the mapped buffer that should be unmapped with
+ * gbm_bo_unmap() when no longer needed. On error, %NULL is returned
+ * and errno is set.
+ *
+ * \sa enum gbm_bo_transfer_flags for the list of flags
+ */
+GBM_EXPORT void *
+gbm_bo_map(struct gbm_bo *bo,
+              uint32_t x, uint32_t y,
+              uint32_t width, uint32_t height,
+              uint32_t flags, uint32_t *stride, void **map_data)
+{
+   if (!bo || width == 0 || height == 0 || !stride || !map_data) {
+      errno = EINVAL;
+      return NULL;
+   }
+
+   return bo->gbm->bo_map(bo, x, y, width, height,
+                          flags, stride, map_data);
+}
+
+/**
+ * Unmap a previously mapped region of a gbm buffer object
+ *
+ * This function unmaps a region of a gbm bo for cpu read and/or write
+ * access.
+ *
+ * \param bo The buffer object
+ * \param map_data opaque ptr returned from prior gbm_bo_map
+ */
+GBM_EXPORT void
+gbm_bo_unmap(struct gbm_bo *bo, void *map_data)
+{
+   bo->gbm->bo_unmap(bo, map_data);
 }
 
 /**
@@ -387,7 +595,23 @@ gbm_surface_create(struct gbm_device *gbm,
                    uint32_t width, uint32_t height,
 		   uint32_t format, uint32_t flags)
 {
-   return gbm->surface_create(gbm, width, height, format, flags);
+   return gbm->surface_create(gbm, width, height, format, flags, NULL, 0);
+}
+
+GBM_EXPORT struct gbm_surface *
+gbm_surface_create_with_modifiers(struct gbm_device *gbm,
+                                  uint32_t width, uint32_t height,
+                                  uint32_t format,
+                                  const uint64_t *modifiers,
+                                  const unsigned int count)
+{
+   if ((count && !modifiers) || (modifiers && !count)) {
+      errno = EINVAL;
+      return NULL;
+   }
+
+   return gbm->surface_create(gbm, width, height, format, 0,
+                              modifiers, count);
 }
 
 /**
@@ -455,7 +679,7 @@ gbm_surface_release_buffer(struct gbm_surface *surf, struct gbm_bo *bo)
  *
  * Before starting a new frame, the surface must have a buffer
  * available for rendering.  Initially, a gbm surface will have a free
- * buffer, but after one of more buffers have been locked (\sa
+ * buffer, but after one or more buffers have been locked (\sa
  * gbm_surface_lock_front_buffer()), the application must check for a
  * free buffer before rendering.
  *

--- a/gbm.h
+++ b/gbm.h
@@ -28,14 +28,15 @@
 #ifndef _GBM_H_
 #define _GBM_H_
 
+#define __GBM__ 1
+
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-#define __GBM__ 1
-
-#include <stdint.h>
 
 /**
  * \file gbm.h
@@ -76,6 +77,12 @@ enum gbm_bo_format {
    GBM_BO_FORMAT_ARGB8888
 };
 
+
+/**
+ * The FourCC format codes are taken from the drm_fourcc.h definition, and
+ * re-namespaced. New GBM formats must not be added, unless they are
+ * identical ports from drm_fourcc.
+ */
 #define __gbm_fourcc_code(a,b,c,d) ((uint32_t)(a) | ((uint32_t)(b) << 8) | \
 			      ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24))
 
@@ -83,6 +90,12 @@ enum gbm_bo_format {
 
 /* color index */
 #define GBM_FORMAT_C8		__gbm_fourcc_code('C', '8', ' ', ' ') /* [7:0] C */
+
+/* 8 bpp Red */
+#define GBM_FORMAT_R8		__gbm_fourcc_code('R', '8', ' ', ' ') /* [7:0] R */
+
+/* 16 bpp RG */
+#define GBM_FORMAT_GR88		__gbm_fourcc_code('G', 'R', '8', '8') /* [15:0] G:R 8:8 little endian */
 
 /* 8 bpp RGB */
 #define GBM_FORMAT_RGB332	__gbm_fourcc_code('R', 'G', 'B', '8') /* [7:0] R:G:B 3:3:2 */
@@ -192,10 +205,13 @@ enum gbm_bo_flags {
     */
    GBM_BO_USE_SCANOUT      = (1 << 0),
    /**
-    * Buffer is going to be used as cursor - the dimensions for the buffer
-    * must be 64x64 if this flag is passed.
+    * Buffer is going to be used as cursor
     */
-   GBM_BO_USE_CURSOR_64X64 = (1 << 1),
+   GBM_BO_USE_CURSOR       = (1 << 1),
+   /**
+    * Deprecated
+    */
+   GBM_BO_USE_CURSOR_64X64 = GBM_BO_USE_CURSOR,
    /**
     * Buffer is to be used for rendering - for example it is going to be used
     * as the storage for a color buffer
@@ -203,10 +219,13 @@ enum gbm_bo_flags {
    GBM_BO_USE_RENDERING    = (1 << 2),
    /**
     * Buffer can be used for gbm_bo_write.  This is guaranteed to work
-    * with GBM_BO_USE_CURSOR_64X64. but may not work for other
-    * combinations.
+    * with GBM_BO_USE_CURSOR, but may not work for other combinations.
     */
    GBM_BO_USE_WRITE    = (1 << 3),
+   /**
+    * Buffer is linear, i.e. not tiled.
+    */
+   GBM_BO_USE_LINEAR = (1 << 4),
 };
 
 int
@@ -219,6 +238,11 @@ int
 gbm_device_is_format_supported(struct gbm_device *gbm,
                                uint32_t format, uint32_t usage);
 
+int
+gbm_device_get_format_modifier_plane_count(struct gbm_device *gbm,
+                                           uint32_t format,
+                                           uint64_t modifier);
+
 void
 gbm_device_destroy(struct gbm_device *gbm);
 
@@ -230,21 +254,74 @@ gbm_bo_create(struct gbm_device *gbm,
               uint32_t width, uint32_t height,
               uint32_t format, uint32_t flags);
 
+struct gbm_bo *
+gbm_bo_create_with_modifiers(struct gbm_device *gbm,
+                             uint32_t width, uint32_t height,
+                             uint32_t format,
+                             const uint64_t *modifiers,
+                             const unsigned int count);
 #define GBM_BO_IMPORT_WL_BUFFER         0x5501
 #define GBM_BO_IMPORT_EGL_IMAGE         0x5502
 #define GBM_BO_IMPORT_FD                0x5503
+#define GBM_BO_IMPORT_FD_MODIFIER       0x5504
 
 struct gbm_import_fd_data {
-    int fd;
-    uint32_t width;
-    uint32_t height;
-    uint32_t stride;
-    uint32_t format;
+   int fd;
+   uint32_t width;
+   uint32_t height;
+   uint32_t stride;
+   uint32_t format;
+};
+
+struct gbm_import_fd_modifier_data {
+   uint32_t width;
+   uint32_t height;
+   uint32_t format;
+   uint32_t num_fds;
+   int fds[4];
+   int strides[4];
+   int offsets[4];
+   uint64_t modifier;
 };
 
 struct gbm_bo *
 gbm_bo_import(struct gbm_device *gbm, uint32_t type,
               void *buffer, uint32_t usage);
+
+/**
+ * Flags to indicate the type of mapping for the buffer - these are
+ * passed into gbm_bo_map(). The caller must set the union of all the
+ * flags that are appropriate.
+ *
+ * These flags are independent of the GBM_BO_USE_* creation flags. However,
+ * mapping the buffer may require copying to/from a staging buffer.
+ *
+ * See also: pipe_transfer_usage
+ */
+enum gbm_bo_transfer_flags {
+   /**
+    * Buffer contents read back (or accessed directly) at transfer
+    * create time.
+    */
+   GBM_BO_TRANSFER_READ       = (1 << 0),
+   /**
+    * Buffer contents will be written back at unmap time
+    * (or modified as a result of being accessed directly).
+    */
+   GBM_BO_TRANSFER_WRITE      = (1 << 1),
+   /**
+    * Read/modify/write
+    */
+   GBM_BO_TRANSFER_READ_WRITE = (GBM_BO_TRANSFER_READ | GBM_BO_TRANSFER_WRITE),
+};
+
+void *
+gbm_bo_map(struct gbm_bo *bo,
+           uint32_t x, uint32_t y, uint32_t width, uint32_t height,
+           uint32_t flags, uint32_t *stride, void **map_data);
+
+void
+gbm_bo_unmap(struct gbm_bo *bo, void *map_data);
 
 uint32_t
 gbm_bo_get_width(struct gbm_bo *bo);
@@ -256,13 +333,34 @@ uint32_t
 gbm_bo_get_stride(struct gbm_bo *bo);
 
 uint32_t
+gbm_bo_get_stride_for_plane(struct gbm_bo *bo, int plane);
+
+uint32_t
 gbm_bo_get_format(struct gbm_bo *bo);
+
+uint32_t
+gbm_bo_get_bpp(struct gbm_bo *bo);
+
+uint32_t
+gbm_bo_get_offset(struct gbm_bo *bo, int plane);
 
 struct gbm_device *
 gbm_bo_get_device(struct gbm_bo *bo);
 
 union gbm_bo_handle
 gbm_bo_get_handle(struct gbm_bo *bo);
+
+int
+gbm_bo_get_fd(struct gbm_bo *bo);
+
+uint64_t
+gbm_bo_get_modifier(struct gbm_bo *bo);
+
+int
+gbm_bo_get_plane_count(struct gbm_bo *bo);
+
+union gbm_bo_handle
+gbm_bo_get_handle_for_plane(struct gbm_bo *bo, int plane);
 
 int
 gbm_bo_write(struct gbm_bo *bo, const void *buf, size_t count);
@@ -281,6 +379,15 @@ struct gbm_surface *
 gbm_surface_create(struct gbm_device *gbm,
                    uint32_t width, uint32_t height,
 		   uint32_t format, uint32_t flags);
+
+struct gbm_surface *
+gbm_surface_create_with_modifiers(struct gbm_device *gbm,
+                                  uint32_t width, uint32_t height,
+                                  uint32_t format,
+                                  const uint64_t *modifiers,
+                                  const unsigned int count);
+int
+gbm_surface_needs_lock_front_buffer(struct gbm_surface *surface);
 
 struct gbm_bo *
 gbm_surface_lock_front_buffer(struct gbm_surface *surface);

--- a/gbmint.h
+++ b/gbmint.h
@@ -32,7 +32,7 @@
 #include <sys/stat.h>
 
 /* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined(__GNUC__)
 #define GBM_EXPORT __attribute__ ((visibility("default")))
 #else
 #define GBM_EXPORT
@@ -61,19 +61,38 @@ struct gbm_device {
    int (*is_format_supported)(struct gbm_device *gbm,
                               uint32_t format,
                               uint32_t usage);
+   int (*get_format_modifier_plane_count)(struct gbm_device *device,
+                                          uint32_t format,
+                                          uint64_t modifier);
 
    struct gbm_bo *(*bo_create)(struct gbm_device *gbm,
                                uint32_t width, uint32_t height,
                                uint32_t format,
-                               uint32_t usage);
+                               uint32_t usage,
+                               const uint64_t *modifiers,
+                               const unsigned int count);
    struct gbm_bo *(*bo_import)(struct gbm_device *gbm, uint32_t type,
                                void *buffer, uint32_t usage);
+   void *(*bo_map)(struct gbm_bo *bo,
+                               uint32_t x, uint32_t y,
+                               uint32_t width, uint32_t height,
+                               uint32_t flags, uint32_t *stride,
+                               void **map_data);
+   void (*bo_unmap)(struct gbm_bo *bo, void *map_data);
    int (*bo_write)(struct gbm_bo *bo, const void *buf, size_t data);
+   int (*bo_get_fd)(struct gbm_bo *bo);
+   int (*bo_get_planes)(struct gbm_bo *bo);
+   union gbm_bo_handle (*bo_get_handle)(struct gbm_bo *bo, int plane);
+   uint32_t (*bo_get_stride)(struct gbm_bo *bo, int plane);
+   uint32_t (*bo_get_offset)(struct gbm_bo *bo, int plane);
+   uint64_t (*bo_get_modifier)(struct gbm_bo *bo);
    void (*bo_destroy)(struct gbm_bo *bo);
 
    struct gbm_surface *(*surface_create)(struct gbm_device *gbm,
                                          uint32_t width, uint32_t height,
-                                         uint32_t format, uint32_t flags);
+                                         uint32_t format, uint32_t flags,
+                                         const uint64_t *modifiers,
+                                         const unsigned count);
    struct gbm_bo *(*surface_lock_front_buffer)(struct gbm_surface *surface);
    void (*surface_release_buffer)(struct gbm_surface *surface,
                                   struct gbm_bo *bo);
@@ -103,14 +122,15 @@ struct gbm_surface {
    uint32_t height;
    uint32_t format;
    uint32_t flags;
+   struct {
+      uint64_t *modifiers;
+      unsigned count;
+   };
 };
 
 struct gbm_backend {
    const char *backend_name;
    struct gbm_device *(*create_device)(int fd);
 };
-
-GBM_EXPORT struct gbm_device *
-_gbm_mesa_get_device(int fd);
 
 #endif


### PR DESCRIPTION
This PR aligns application interface of libgbm to mesa 17.3 libgbm. Implementation of these APIs are mostly empty for now.

The version update for libgbm is required for proper hardware plane and multi planar buffer support in weston. Please check this branch "https://gitlab.collabora.com/daniels/weston/commits/wip/2018-02/atomic-v16-WIP" to see upcoming weston changes, which requires an up-to-date version of libgbm.

Please note that gpu drivers has to be recompiled to test this PR. Because gbm_surface and gbm_kms_surface struct size are changed.