### PR TITLE
Add support to track the active bo handles

### DIFF
--- a/backend_kms.c
+++ b/backend_kms.c
@@ -178,13 +178,16 @@ static void gbm_kms_bo_destroy(struct gbm_bo *_bo)
 
 		if (bo->bo)
 			kms_bo_destroy(&bo->bo);
-	} else if (bo->num_planes == 1) {
-		gbm_kms_bo_close_handle(bo->base.gbm->fd, bo->base.handle.u32);
-	} else {
-		int i;
-		for (i = 0; i < bo->num_planes; i++) {
+	} else if (bo->allocated_handle) {
+		if (bo->num_planes == 1) {
 			gbm_kms_bo_close_handle(bo->base.gbm->fd,
-						bo->planes[i].handle);
+						bo->base.handle.u32);
+		} else {
+			int i;
+			for (i = 0; i < bo->num_planes; i++) {
+				gbm_kms_bo_close_handle(bo->base.gbm->fd,
+							bo->planes[i].handle);
+			}
 		}
 	}
 
@@ -451,6 +454,7 @@ static struct gbm_kms_bo* gbm_kms_import_fd(struct gbm_device *gbm,
 	bo->base.stride = fd_data->stride;
 	bo->base.handle.u32 = handle;
 	bo->num_planes = 1;
+	bo->allocated_handle = true;
 
 	return bo;
 }
@@ -494,6 +498,7 @@ static struct gbm_kms_bo *gbm_kms_import_fd_modifier(struct gbm_device *gbm,
 	bo->base.format = gbm_format_canonicalize(fd_data->format);
 	bo->base.stride = fd_data->strides[0];
 	bo->base.handle.u32 = handle[0];
+	bo->allocated_handle = true;
 
 	bo->num_planes = fd_data->num_fds;
 	for (i = 0; i < fd_data->num_fds; i++)  {

--- a/gbm_kmsint.h
+++ b/gbm_kmsint.h
@@ -55,6 +55,7 @@ struct gbm_kms_bo {
 
 	uint32_t size;
 	bool allocated;
+	bool allocated_handle;
 
 	// for multi-planar support
 	int num_planes;

--- a/gbm_kmsint.h
+++ b/gbm_kmsint.h
@@ -30,12 +30,25 @@
 
 #include <libkms.h>
 #include <stdbool.h>
+#include <sys/queue.h>
 
 #include "gbmint.h"
+
+struct gbm_kms_bo_handle_list {
+	uint32_t handle;
+	unsigned int ref_count;
+	bool allocated_handle;
+
+	TAILQ_ENTRY(gbm_kms_bo_handle_list) entry;
+};
+
+TAILQ_HEAD(tailq_head, gbm_kms_bo_handle_list);
 
 struct gbm_kms_device {
 	struct gbm_device base;
 	struct kms_driver *kms;
+
+	struct tailq_head bo_handle_list;
 };
 
 #define MAX_PLANES	3
@@ -55,7 +68,6 @@ struct gbm_kms_bo {
 
 	uint32_t size;
 	bool allocated;
-	bool allocated_handle;
 
 	// for multi-planar support
 	int num_planes;


### PR DESCRIPTION
The handle of EGL buffers is unnecessarily removed in use-cases where multiple linux DMA buffers and EGL buffers are imported. The issue is observed when the same linux DMA buffers are imported multiple times.

To avoid the issue, add ref count tracing of the buffer object handles used in libgbm.

Also, it seems logical to move the allocated_handle flag to the structure tracking buffer object handles.


Test setup with which issue is observed:
1) Weston 8 with IVI-shell (with HW plane assignment enabled)
2) demo applications with would submit linux DMA buffers and EGL legacy buffers (kms buffers) to Weston.

**Issue scenario:**

If HW plane assignment is enabled, Weston will fetch the gbm bo for linux DMA buffers/EGL buffers using gbm_bo_import().

In current libgbm implementation, for gbm_bo_import:

> 	a) for GBM_BO_IMPORT_FD/GBM_BO_IMPORT_FD_MODIFIER: bo handle is generated using the provided buffer fd.
> 	b) for GBM_BO_IMPORT_WL_BUFFER: bo handle (which is already generated while creating kms buffer) is copied to the gbm structure

and for gbm_bo_destroy:

> 	a) for GBM_BO_IMPORT_FD/GBM_BO_IMPORT_FD_MODIFIER: bo handle generated is destroyed and gbm structure is freed.
> 	b) for GBM_BO_IMPORT_WL_BUFFER: gbm structure is freed. (bo handle shouldn't be destroyed as it was never generated [!2](https://github.com/renesas-rcar/libgbm/pull/2))

Now consider a scenario where the same surface (having DMA buffers attached) is placed in different logical layers using IVI-shell. So Weston calls gbm_bo_import(GBM_BO_IMPORT_FD) for the different views having the same buffer. For the first import, bo handle [a] is generated for fd [x] using drmPrimeFDToHandle(), but for the second import of the same buffer, drmPrimeFDToHandle() will again provide the same handle [a] for the fd [x]. And while destroying the gbm bo, tries to remove handle [a] twice.

On top of the above scenario, we started running demo applications with would provide EGL buffers, now a corner case is created:

> 1) gbm_bo_import() called for view [v1] (has DMA buffer [b1]) 	: bo handle [a] is generated for fd [x]
> 2) gbm_bo_import() called for view [v2] (has DMA buffer [b1]) 	: bo handle [a] is retrived for fd [x]
> 3) gbm_bo_destroy() is called for view [v1] : bo handle [a] is destroyed (now handle [a] is free)
> 4) demo application is started that will provide EGL buffers: kms bo is created for the application and bo handle assigned for that kms bo is [a]. (as handle [a] was freed earlier)
> 5) gbm_bo_destroy() is called for view [v2] : bo handle [a] is unnecessarily feed (handle [a] of the kms buffer goes invalid)

Now, black screen/artifacts are observed on the display.

**Solution:**

Add ref count tracing of the buffer object handles used in libgbm.

> 1) gbm_bo_import() called for view [v1] (has DMA buffer [b1]) 	: bo handle [a] is generated for fd [x] :: handle [a] ref-count: 1
> 2) gbm_bo_import() called for view [v2] (has DMA buffer [b1]) 	: bo handle [a] is retrived for fd [x] :: handle [a] ref-count: 2
> 3) gbm_bo_destroy() is called for view [v1] : bo handle [a] is not freed :: handle [a] ref-count: 1
> 4) demo application is started that will provide EGL buffers : kms bo is created for the application and bo handle assigned for that kms bo is [c] .  (as handle [a] was not freed earlier)
> 5) gbm_bo_destroy() is called for view [v2] : bo handle [a] is freed :: handle [a] ref-count: 0